### PR TITLE
removes symlink from build

### DIFF
--- a/ros_nodes/Makefile
+++ b/ros_nodes/Makefile
@@ -24,8 +24,6 @@ pipeline:
 provision:
 	vcs import < required.repos . --recursive
 	vcs --nested custom --git --args show
-	rm -rf ros2/tofcore_ros/libtofcore ros2/tofcore_discovery/libtofcore ros1/tofcore_ros/libtofcore
-	cd ros2 && ln -fs ../../libtofcore tofcore_ros/libtofcore
 
 .PHONY: provision_bridge
 provision_bridge: provision ##	Install required tools, packages and git repos to build the truenense package as well as the ROS bridge package
@@ -39,16 +37,15 @@ provision_ros1: provision ##	Install required tools, packages and git repos to b
 	sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(TARGET_DISTRO_VER) main" > /etc/apt/sources.list.d/ros-noetic.list'
 	curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
 	sudo apt update && sudo apt install -y ros-noetic-desktop-full python3-catkin-pkg
-	cd ros1 && ln -fs ../../libtofcore tofcore_ros/libtofcore
 
 
 .PHONY: ros2
 ros2:
-	 export PREACT_CPPCHECK_ENABLE="OFF" && cd ros2 && colcon build --packages-skip ros1_bridge preact_alg detection_py lens_calibration 
+	cd ros2 && colcon build --packages-skip ros1_bridge preact_alg detection_py lens_calibration 
 	 
 .PHONY: ros1
 ros1:
-	 export PREACT_CPPCHECK_ENABLE="OFF" && cd ros1 &&  source /opt/ros/noetic/setup.bash && colcon build
+	cd ros1 &&  source /opt/ros/noetic/setup.bash && colcon build
 
 .PHONY: bridge
 bridge: build ##	Build the ROS1 bridge, build environment must have both ROS1 and ROS2 installed
@@ -79,5 +76,5 @@ clean:
 	rm -r -f *.zsync
 .PHONY: clobber
 clobber: clean
-	rm -rf ros2/tofcore_ros/libtofcore ros1/tofcore_ros/libtofcore algorithm ros2/algorithm
+	rm -rf algorithm ros2/algorithm
 	rm -r -f ros1_bridge

--- a/ros_nodes/ros1/tofcore_ros/CMakeLists.txt
+++ b/ros_nodes/ros1/tofcore_ros/CMakeLists.txt
@@ -4,6 +4,8 @@ project(tofcore_ros1)
 ## Compile as C++11, supported in ROS Kinetic and newer
 # add_compile_options(-std=c++11)
 
+set(ENV{PREACT_CPPCHECK_ENABLE} "OFF")
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
@@ -22,13 +24,12 @@ find_package( OpenCV REQUIRED )
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 
-find_package(ToFCore QUIET)
 if(NOT TARGET ToFCore::ToFCore)
-  if (EXISTS "${CMAKE_SOURCE_DIR}/libtofcore" AND EXISTS "${CMAKE_SOURCE_DIR}/libtofcore/CMakeLists.txt")
+  if (EXISTS "${CMAKE_SOURCE_DIR}/../../libtofcore" AND EXISTS "${CMAKE_SOURCE_DIR}/../../libtofcore/CMakeLists.txt")
     set(BUILD_PYTHON_BINDINGS OFF)
-    add_subdirectory(libtofcore/tofcore)
+    add_subdirectory(../../libtofcore/tofcore ${CMAKE_CURRENT_BINARY_DIR}/tofcore)
   else()
-    message(FATAL_ERROR "ToFCore library must be installed to ${CMAKE_INSTALL_PREFIX} OR present at ${CMAKE_SOURCE_DIR}/libtofcore")
+    message(FATAL_ERROR "ToFCore library must be installed to ${CMAKE_SOURCE_DIR}/../../libtofcore")
   endif()
 endif()
 

--- a/ros_nodes/ros2/tofcore_ros/CMakeLists.txt
+++ b/ros_nodes/ros2/tofcore_ros/CMakeLists.txt
@@ -5,6 +5,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+set(ENV{PREACT_CPPCHECK_ENABLE} "OFF")
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
@@ -19,13 +20,12 @@ find_package(rosidl_typesupport_cpp REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 
-find_package(ToFCore QUIET)
-if(NOT TARGET ToFCore::ToFCore )
-  if (EXISTS "${CMAKE_SOURCE_DIR}/libtofcore" AND EXISTS "${CMAKE_SOURCE_DIR}/libtofcore/CMakeLists.txt")
+if(NOT TARGET ToFCore::ToFCore)
+  if (EXISTS "${CMAKE_SOURCE_DIR}/../../libtofcore" AND EXISTS "${CMAKE_SOURCE_DIR}/../../libtofcore/CMakeLists.txt")
     set(BUILD_PYTHON_BINDINGS OFF)
-    add_subdirectory(libtofcore/tofcore)
+    add_subdirectory(../../libtofcore/tofcore ${CMAKE_CURRENT_BINARY_DIR}/tofcore)
   else()
-    message(FATAL_ERROR "ToFCore library must be installed to ${CMAKE_INSTALL_PREFIX} OR present at ${CMAKE_SOURCE_DIR}/libtofcore")
+    message(FATAL_ERROR "ToFCore library must be installed to ${CMAKE_SOURCE_DIR}/../../libtofcore")
   endif()
 endif()
 


### PR DESCRIPTION
change log
    removes symlink from build process
    adds not-so-elegant cmake subdirectory logic to replace symlink
    cleans make commands
    moves setting PREACT_CPPCHECK_ENABLE to cmakelists

ROS 2 can build built from repo root via colcon build --packages-skip tofcore_ros1

NOTE: ROS 1 build was not tested.
