### PR TITLE
Feature/ros2 filters

### DIFF
--- a/ros_nodes/ros2/tofcore_ros/CMakeLists.txt
+++ b/ros_nodes/ros2/tofcore_ros/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(tofcore_msgs REQUIRED)
 find_package(rosidl_typesupport_c REQUIRED)
 find_package(rosidl_typesupport_cpp REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(OpenCV REQUIRED)
 
 
 if(NOT TARGET ToFCore::ToFCore)
@@ -40,7 +41,7 @@ target_include_directories(tof_sensor PUBLIC
   )
 target_compile_features(tof_sensor PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 ament_target_dependencies(tof_sensor rclcpp std_msgs sensor_msgs tofcore_msgs )
-target_link_libraries(tof_sensor tofcore)
+target_link_libraries(tof_sensor tofcore ${OpenCV_LIBS})
 
 
 

--- a/ros_nodes/ros2/tofcore_ros/config/filter_example.yaml
+++ b/ros_nodes/ros2/tofcore_ros/config/filter_example.yaml
@@ -1,0 +1,20 @@
+/tof_sensor:
+  ros__parameters:
+    integration_time: 500
+    modulation_frequency: 12000
+    minimum_amplitude: 10
+    maximum_amplitude: 2000
+    flip_horizontal: false
+    flip_vertical: false
+    binning: true
+    median_filter: true
+    median_kernel: 3
+    bilateral_filter: false
+    bilateral_kernel: 5
+    bilateral_color: 75
+    bilateral_space: 75
+    gradient_filter: true
+    gradient_kernel: 1
+    gradient_threshold: 250
+    gradient_filter_support: 6
+    stream_type: distance_amplitude

--- a/ros_nodes/ros2/tofcore_ros/include/sensor_node.hpp
+++ b/ros_nodes/ros2/tofcore_ros/include/sensor_node.hpp
@@ -41,6 +41,18 @@ class ToFSensor : public rclcpp::Node
     tofcore::CartesianTransform cartesianTransform_;
     std::string sensor_location_;
 
+    bool median_filter_{false};
+    int median_kernel_{3};
+    bool bilateral_filter_{false};
+    int bilateral_kernel_{5};
+    int bilateral_color_{75};
+    int bilateral_space_{75};
+    int maximum_amplitude_{2000};
+    bool gradient_filter_{true};
+    int gradient_kernel_{1};
+    int gradient_threshold_{50};
+    int gradient_filter_support_{6};
+
   public:
     /// Standard constructor
     ToFSensor();
@@ -86,6 +98,9 @@ class ToFSensor : public rclcpp::Node
     void apply_binning_param(const rclcpp::Parameter& parameter, rcl_interfaces::msg::SetParametersResult& result);
     void apply_sensor_name_param(const rclcpp::Parameter& parameter, rcl_interfaces::msg::SetParametersResult& result);
     void apply_sensor_location_param(const rclcpp::Parameter& parameter, rcl_interfaces::msg::SetParametersResult& result);
+
+    void apply_param(bool& param, const rclcpp::Parameter& parameter);
+    void apply_param(int& param, const rclcpp::Parameter& parameter);
 
 };
 

--- a/ros_nodes/ros2/tofcore_ros/include/sensor_node.hpp
+++ b/ros_nodes/ros2/tofcore_ros/include/sensor_node.hpp
@@ -22,6 +22,10 @@
 
 #include <tofcore_msgs/msg/integration_time.hpp>
 
+#include <opencv2/core.hpp>
+#include <opencv2/imgproc.hpp>
+#include <opencv2/opencv.hpp>
+
 /// ToFSensor ROS2 node class for interacting with a PreAct ToF sensor/camera
 class ToFSensor : public rclcpp::Node
 {
@@ -47,6 +51,7 @@ class ToFSensor : public rclcpp::Node
     int bilateral_kernel_{5};
     int bilateral_color_{75};
     int bilateral_space_{75};
+    int minimum_amplitude_{0};
     int maximum_amplitude_{2000};
     bool gradient_filter_{true};
     int gradient_kernel_{1};

--- a/ros_nodes/ros2/tofcore_ros/launch/tofcore.launch.py
+++ b/ros_nodes/ros2/tofcore_ros/launch/tofcore.launch.py
@@ -78,7 +78,7 @@ def launch_setup(context, *args, **kwargs):
 def generate_launch_description():
     pkg_share = FindPackageShare(package='tof_sensor').find('tof_sensor')
     default_rviz_config_path = os.path.join(pkg_share, 'rviz2/tofcore_basic_cloud.rviz')
-    defaul_config_path = os.path.join(pkg_share, 'config/config.yaml')
+    default_config_path = os.path.join(pkg_share, 'config/config.yaml')
 
     rvizconfig = DeclareLaunchArgument(
         name='rvizconfig',
@@ -87,7 +87,7 @@ def generate_launch_description():
     
     config = DeclareLaunchArgument(
         name='config',
-        default_value=defaul_config_path,
+        default_value=default_config_path,
         description='Absolute path to ae config file')
   
     with_ros1_bridge = DeclareLaunchArgument(name='with_ros1_bridge', default_value='false',

--- a/ros_nodes/ros2/tofcore_ros/src/sensor_node.cpp
+++ b/ros_nodes/ros2/tofcore_ros/src/sensor_node.cpp
@@ -26,11 +26,25 @@ constexpr auto STREAMING_STATE = "streaming";
 constexpr auto MODULATION_FREQUENCY = "modulation_frequency";
 constexpr auto DISTANCE_OFFSET = "distance_offset";
 constexpr auto MINIMUM_AMPLITUDE = "minimum_amplitude";
+constexpr auto MAXIMUM_AMPLITUDE = "maximum_amplitude";
 constexpr auto FLIP_HORIZONTAL = "flip_horizontal";
 constexpr auto FLIP_VERITCAL = "flip_vertical";
 constexpr auto BINNING = "binning";
 constexpr auto SENSOR_NAME = "sensor_name";
 constexpr auto SENSOR_LOCATION = "sensor_location";
+
+// Filter parameters
+constexpr auto MEDIAN_FILTER = "median_filter";
+constexpr auto MEDIAN_KERNEL = "median_kernel";
+constexpr auto BILATERAL_FILTER = "bilateral_filter";
+constexpr auto BILATERAL_KERNEL = "bilateral_kernel";
+constexpr auto BILATERAL_COLOR = "bilateral_color";
+constexpr auto BILATERAL_SPACE = "bilateral_space";
+
+constexpr auto GRADIENT_FILTER = "gradient_filter";
+constexpr auto GRADIENT_KERNEL = "gradient_kernel";
+constexpr auto GRADIENT_THRESHOLD = "gradient_threshold";
+constexpr auto GRADIENT_FILTER_SUPPORT = "gradient_filter_support";
 
 /// Quick helper function that return true if the string haystack starts with the string needle
 bool begins_with(const std::string &needle, const std::string &haystack)
@@ -78,9 +92,21 @@ ToFSensor::ToFSensor()
   this->declare_parameter(MODULATION_FREQUENCY, 12000);
   this->declare_parameter(DISTANCE_OFFSET, 0);
   this->declare_parameter(MINIMUM_AMPLITUDE, 0);
+  this->declare_parameter(MAXIMUM_AMPLITUDE, 2000);
   this->declare_parameter(FLIP_HORIZONTAL, false);
   this->declare_parameter(FLIP_VERITCAL, false);
   this->declare_parameter(BINNING, false);
+
+  this->declare_parameter(MEDIAN_FILTER, false);
+  this->declare_parameter(MEDIAN_KERNEL, 3);
+  this->declare_parameter(BILATERAL_FILTER, false);
+  this->declare_parameter(BILATERAL_KERNEL, 5);
+  this->declare_parameter(BILATERAL_COLOR, 75);
+  this->declare_parameter(BILATERAL_SPACE, 75);
+  this->declare_parameter(GRADIENT_FILTER, false);
+  this->declare_parameter(GRADIENT_KERNEL, 1);
+  this->declare_parameter(GRADIENT_THRESHOLD, 50);
+  this->declare_parameter(GRADIENT_FILTER_SUPPORT, 6);
 
   // Reading optional values from sensor
   std::optional<std::string> init_name = interface_->getSensorName();
@@ -180,6 +206,10 @@ rcl_interfaces::msg::SetParametersResult ToFSensor::on_set_parameters_callback(
     {
       this->apply_minimum_amplitude_param(parameter, result);
     }
+    else if (name == MAXIMUM_AMPLITUDE)
+    {
+      this->apply_param(maximum_amplitude_, parameter);
+    }
     else if (name == FLIP_HORIZONTAL)
     {
       this->apply_flip_horizontal_param(parameter, result);
@@ -199,6 +229,46 @@ rcl_interfaces::msg::SetParametersResult ToFSensor::on_set_parameters_callback(
     else if (name == SENSOR_LOCATION)
     {
       this->apply_sensor_location_param(parameter, result);
+    }
+    else if (name == MEDIAN_FILTER)
+    {
+      this->apply_param(median_filter_, parameter);
+    }
+    else if (name == MEDIAN_KERNEL)
+    {
+      this->apply_param(median_kernel_, parameter);
+    }
+    else if (name == BILATERAL_FILTER)
+    {
+      this->apply_param(bilateral_filter_, parameter);
+    }
+    else if (name == BILATERAL_KERNEL)
+    {
+      this->apply_param(bilateral_kernel_, parameter);
+    }
+    else if (name == BILATERAL_COLOR)
+    {
+      this->apply_param(bilateral_color_, parameter);
+    }
+    else if (name == BILATERAL_SPACE)
+    {
+      this->apply_param(bilateral_space_, parameter);
+    }
+    else if (name == GRADIENT_FILTER)
+    {
+      this->apply_param(gradient_filter_, parameter);
+    }
+    else if (name == GRADIENT_KERNEL)
+    {
+      this->apply_param(gradient_kernel_, parameter);
+    }
+    else if (name == GRADIENT_THRESHOLD)
+    {
+      this->apply_param(gradient_threshold_, parameter);
+    }
+    else if (name == GRADIENT_FILTER_SUPPORT)
+    {
+      this->apply_param(gradient_filter_support_, parameter);
     }
   }
   return result;
@@ -410,6 +480,21 @@ void ToFSensor::apply_sensor_location_param(const rclcpp::Parameter &parameter, 
   interface_->storeSettings();
   this->sensor_location_ = value;
 }
+
+void ToFSensor::apply_param(bool& param, const rclcpp::Parameter& parameter)
+{
+  auto value = parameter.as_bool();
+  RCLCPP_INFO(this->get_logger(), "Handling parameter \"%s\" : %s", parameter.get_name().c_str(), (value ? "true" : "false"));
+  param = value;
+}
+
+void ToFSensor::apply_param(int& param, const rclcpp::Parameter& parameter)
+{
+  auto value = parameter.as_int();
+  RCLCPP_INFO(this->get_logger(), "Handling parameter \"%s\" : %ld", parameter.get_name().c_str(), value);
+  param = value;
+}
+
 void ToFSensor::publish_tempData(const tofcore::Measurement_T &frame, const rclcpp::Time &stamp)
 {
   const std::array<float, 4> defaultTemps{0.0, 0.0, 0.0, 0.0};


### PR DESCRIPTION
changelog
- maximum amplitude param
- added params for median, bilateral, and gradient filters
- ported median, bilateral, and gradient filters from ros1 implementation
- pointcloud NaN values on filtered invalids not ported, set `valid=0` instead
- ported minimum and maximum amplitude filter from ros1 implementation
- added example config for apply filters